### PR TITLE
GCP cert fix and automated kubeconfig for shell

### DIFF
--- a/cmd/eiam/internal/appconfig/generate_certs.go
+++ b/cmd/eiam/internal/appconfig/generate_certs.go
@@ -40,8 +40,12 @@ func GenerateCerts() error {
 			OrganizationalUnit: []string{"Unknown"},
 			CommonName:         "Unknown",
 		},
-		NotBefore: notBefore,
-		NotAfter:  notAfter,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)

--- a/cmd/eiam/internal/appconfig/setup.go
+++ b/cmd/eiam/internal/appconfig/setup.go
@@ -32,7 +32,7 @@ func init() {
 		}
 	}
 
-	util.NewLogger()
+	util.Logger = util.NewLogger()
 
 	allConfigKeys := viper.AllKeys()
 	if !util.Contains(allConfigKeys, "binarypaths.gcloud") && !util.Contains(allConfigKeys, "binarypaths.kubectl") {

--- a/cmd/eiam/internal/eiamutil/logger.go
+++ b/cmd/eiam/internal/eiamutil/logger.go
@@ -12,7 +12,7 @@ import (
 var Logger *logrus.Logger
 
 // NewLogger instantiates a new logging instance
-func NewLogger() {
+func NewLogger() *logrus.Logger {
 	logger := logrus.New()
 
 	level, err := logrus.ParseLevel(viper.GetString("logging.level"))
@@ -36,5 +36,5 @@ func NewLogger() {
 		}
 	}
 
-	Logger = logger
+	return logger
 }

--- a/cmd/eiam/internal/gcpclient/gke.go
+++ b/cmd/eiam/internal/gcpclient/gke.go
@@ -1,0 +1,30 @@
+package gcpclient
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/api/container/v1"
+	"google.golang.org/api/option"
+
+	util "github.com/jessesomerville/ephemeral-iam/cmd/eiam/internal/eiamutil"
+)
+
+func GetClusters(project, reason string) ([]map[string]string, error) {
+	gkeService, err := container.NewService(context.Background(), option.WithRequestReason(reason))
+	if err != nil {
+		return []map[string]string{}, &util.SDKClientCreateError{Err: err, ResourceType: "Container"}
+	}
+	clustersService := container.NewProjectsLocationsClustersService(gkeService)
+
+	projectRes := fmt.Sprintf("projects/%s/locations/-", project)
+	if resp, err := clustersService.List(projectRes).Do(); err != nil {
+		return []map[string]string{}, fmt.Errorf("failed to list clusters in %s: %v", project, err)
+	} else {
+		clusterNames := []map[string]string{}
+		for _, cluster := range resp.Clusters {
+			clusterNames = append(clusterNames, map[string]string{"name": cluster.Name, "location": cluster.Location})
+		}
+		return clusterNames, nil
+	}
+}

--- a/cmd/eiam/internal/gcpclient/iam.go
+++ b/cmd/eiam/internal/gcpclient/iam.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/duration"
-	gcp "google.golang.org/api/container/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 	credentialspb "google.golang.org/genproto/googleapis/iam/credentials/v1"
@@ -35,7 +34,7 @@ func GenerateTemporaryAccessToken(serviceAccountEmail, reason string) (*credenti
 		Name:     fmt.Sprintf("projects/-/serviceAccounts/%s", serviceAccountEmail),
 		Lifetime: sessionDuration,
 		Scope: []string{
-			gcp.CloudPlatformScope,
+			iam.CloudPlatformScope,
 			"https://www.googleapis.com/auth/userinfo.email",
 		},
 	}

--- a/cmd/eiam/internal/proxy/ca.go
+++ b/cmd/eiam/internal/proxy/ca.go
@@ -45,7 +45,7 @@ func setCa(caCertFile, caKeyFile string) error {
 	return nil
 }
 
-// See https://github.com/rhaidiz/broxy/core/cert.go
+// See https://github.com/rhaidiz/broxy/blob/master/core/cert.go
 func tlsConfigFromCA(ca *tls.Certificate) func(host string, ctx *goproxy.ProxyCtx) (*tls.Config, error) {
 	return func(host string, ctx *goproxy.ProxyCtx) (c *tls.Config, err error) {
 		parts := strings.SplitN(host, ":", 2)
@@ -76,7 +76,7 @@ func tlsConfigFromCA(ca *tls.Certificate) func(host string, ctx *goproxy.ProxyCt
 	}
 }
 
-// See https://github.com/rhaidiz/broxy/core/cert.go
+// See https://github.com/rhaidiz/broxy/blob/master/core/cert.go
 func signHost(ca *tls.Certificate, host string, port int) (cert *tls.Certificate, err error) {
 	var x509ca *x509.Certificate
 	var template x509.Certificate
@@ -100,8 +100,8 @@ func signHost(ca *tls.Certificate, host string, port int) (cert *tls.Certificate
 		Subject: pkix.Name{
 			Country:            []string{"US"},
 			Locality:           []string{""},
-			Organization:       []string{""},
-			OrganizationalUnit: []string{""},
+			Organization:       []string{"ephemeral-iam"},
+			OrganizationalUnit: []string{"https://praetorian.com/"},
 			CommonName:         "gcloud proxy cert",
 		},
 		NotBefore: notBefore,


### PR DESCRIPTION
- Fixed issues with GCP certificate trust
- Credentials for kubectl are now automatically generated when starting a privileged subshell